### PR TITLE
Bugfix: lock mysql image to version 8.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - db:db
 
   db:
-    image: mysql:latest # https://hub.docker.com/_/mysql/ - or mariadb https://hub.docker.com/_/mariadb
+    image: mysql:8.3 # https://hub.docker.com/_/mysql/ - or mariadb https://hub.docker.com/_/mariadb
     ports:
       - 127.0.0.1:3307:3306 # change ip if required
     command: [


### PR DESCRIPTION
#### Description of the bug
The mysql container automatically shuts down when started. See image below. 

![image](https://github.com/user-attachments/assets/50975e56-0b56-459a-b085-ce63d508e890)

#### Analysis
The latest version of mysql in the [mysql official image](https://hub.docker.com/_/mysql) is 9.0. 
The `default-authentication-plugin` was [removed in version 8.4](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html#:~:text=Important%20Change%3A%20The%20deprecated%20mysql_native_password,of%20your%20MySQL%20configuration%20file.). 
Its successor, `mysql_native_password` was [removed in version 9.0](https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html). 

#### Solution
This PR locks the mysql version in the docker-compose configuration of the project to make it work as originally intended. 